### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'doocs/advanced-java'
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Compress Images
         id: calibre

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -17,7 +17,7 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/deploy.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/compress.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/deploy.yml`
